### PR TITLE
Add semver check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/install-action@v2
-        with: { tool: "just,cargo-semver-checks" }
+        with: { tool: "just" }
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Build
         run: cargo build --verbose
       - run: just ci-test
-      - name: Check if changes break public API and require a new version
-        run: just semver-checks
-
+      - name: Check if changes break public API and need a new version. Use `just semver-checks` to run locally.
+        uses: obi1kenobi/cargo-semver-checks-action@v2
   msrv:
     name: Test MSRV
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/install-action@v2
-        with: { tool: just }
+        with: { tool: "just,cargo-semver-checks" }
       - uses: actions/checkout@v4
-      - name: Build
-        run: cargo build --verbose
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Build
+        run: cargo build --verbose
       - run: just ci-test
+      - name: Check if changes break public API and require a new version
+        run: just semver-checks
 
   msrv:
     name: Test MSRV
@@ -39,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
-      - name: Read crate metadata
+      - name: Read rust-version from Cargo.toml
         id: metadata
         run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
       - name: Install Rust

--- a/justfile
+++ b/justfile
@@ -42,9 +42,12 @@ sys-info:
     cargo --version
     {{ just_executable() }} --version
 
-# All tests to run for CI
+# All tests to run for CI (TODO: add clippy)
 ci-test: sys-info (fmt "--check") build test test-doc
-# TODO: clippy
 
 # All stable tests to run for CI with the earliest supported Rust version. Assumes the Rust version is already set by rustup.
 ci-test-msrv: sys-info build test
+
+# Test if changes are backwards compatible (patch), or need a new minor/major version
+semver-checks:
+    cargo semver-checks


### PR DESCRIPTION
* `cargo semver-checks` will alert if the version requires a new minor or major version - i.e. if the public API has changed in an incompatible way.