### PR TITLE
Auto-fixed clippy::mem_replace_with_default

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -36,6 +36,7 @@ use std::env;
 
 use std::fs::File;
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::mem::take;
 
 const MAX_THREADS: usize = 16;
 
@@ -863,7 +864,7 @@ fn main() {
                     };
                 for i in 0..num_benchmarks {
                     if do_validate {
-                        let dict = core::mem::replace(&mut custom_dictionary, Vec::new());
+                        let dict = take(&mut custom_dictionary);
                         if num_benchmarks > 0 {
                             custom_dictionary = dict.clone();
                         }
@@ -917,7 +918,7 @@ fn main() {
                             }
                         }
                     } else {
-                        let dict = core::mem::replace(&mut custom_dictionary, Vec::new());
+                        let dict = take(&mut custom_dictionary);
                         if num_benchmarks > 0 {
                             custom_dictionary = dict.clone();
                         }

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -21,6 +21,7 @@ use enc::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use enc::util::{brotli_max_size_t, floatX, FastLog2, Log2FloorNonZero};
+use std::mem::take;
 
 pub const kInfinity: floatX = 1.7e38 as floatX;
 #[derive(Clone, Copy, Debug)]
@@ -89,10 +90,7 @@ impl<AllocU32: Allocator<u32>> Allocable<u32, AllocU32> for H10Buckets<AllocU32>
         H10Buckets::<AllocU32>(m.alloc_cell(1 << BUCKET_BITS))
     }
     fn free(&mut self, m: &mut AllocU32) {
-        m.free_cell(core::mem::replace(
-            &mut self.0,
-            AllocU32::AllocatedMemory::default(),
-        ));
+        m.free_cell(take(&mut self.0));
     }
 }
 
@@ -199,10 +197,7 @@ where
     Buckets: PartialEq<Buckets>,
 {
     pub fn free(&mut self, m32: &mut AllocU32) {
-        m32.free_cell(core::mem::replace(
-            &mut self.forest,
-            AllocU32::AllocatedMemory::default(),
-        ));
+        m32.free_cell(take(&mut self.forest));
         self.buckets_.free(m32);
     }
 }

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -25,6 +25,7 @@ use enc::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use enc::util::{brotli_max_size_t, floatX, FastLog2, FastLog2f64, Log2FloorNonZero};
+use std::mem::take;
 
 const BROTLI_WINDOW_GAP: usize = 16;
 const BROTLI_MAX_STATIC_DICTIONARY_MATCH_LEN: usize = 37;
@@ -971,16 +972,10 @@ fn CleanupZopfliCostModel<AllocF: Allocator<floatX>>(
     xself: &mut ZopfliCostModel<AllocF>,
 ) {
     {
-        m.free_cell(core::mem::replace(
-            &mut xself.literal_costs_,
-            AllocF::AllocatedMemory::default(),
-        ));
+        m.free_cell(take(&mut xself.literal_costs_));
     }
     {
-        m.free_cell(core::mem::replace(
-            &mut xself.cost_dist_,
-            AllocF::AllocatedMemory::default(),
-        ));
+        m.free_cell(take(&mut xself.cost_dist_));
     }
 }
 
@@ -1198,13 +1193,7 @@ pub fn BrotliCreateZopfliBackwardReferences<
         num_literals,
     );
     {
-        <Alloc as Allocator<ZopfliNode>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut nodes,
-                <Alloc as Allocator<ZopfliNode>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<ZopfliNode>>::free_cell(alloc, take(&mut nodes));
     }
 }
 
@@ -1545,13 +1534,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                         }
                     }
                     {
-                        <Alloc as Allocator<u64>>::free_cell(
-                            alloc,
-                            core::mem::replace(
-                                &mut matches,
-                                <Alloc as Allocator<u64>>::AllocatedMemory::default(),
-                            ),
-                        );
+                        <Alloc as Allocator<u64>>::free_cell(alloc, take(&mut matches));
                     }
                     matches = new_array;
                     matches_size = new_size;

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -15,6 +15,8 @@ use super::static_dict::{
 };
 use super::util::{brotli_max_size_t, floatX, Log2FloorNonZero};
 use core;
+use std::mem::take;
+
 static kBrotliMinWindowBits: i32 = 10i32;
 
 static kBrotliMaxWindowBits: i32 = 24i32;
@@ -2307,120 +2309,36 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> UnionHasher<Alloc> {
     pub fn free(&mut self, alloc: &mut Alloc) {
         match self {
             &mut UnionHasher::H2(ref mut hasher) => {
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets_.buckets_,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets_.buckets_));
             }
             &mut UnionHasher::H3(ref mut hasher) => {
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets_.buckets_,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets_.buckets_));
             }
             &mut UnionHasher::H4(ref mut hasher) => {
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets_.buckets_,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets_.buckets_));
             }
             &mut UnionHasher::H54(ref mut hasher) => {
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets_.buckets_,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets_.buckets_));
             }
             &mut UnionHasher::H5q7(ref mut hasher) => {
-                <Alloc as Allocator<u16>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.num,
-                        <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                    ),
-                );
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut hasher.num));
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets));
             }
             &mut UnionHasher::H5q5(ref mut hasher) => {
-                <Alloc as Allocator<u16>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.num,
-                        <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                    ),
-                );
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut hasher.num));
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets));
             }
             &mut UnionHasher::H5(ref mut hasher) => {
-                <Alloc as Allocator<u16>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.num,
-                        <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                    ),
-                );
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut hasher.num));
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets));
             }
             &mut UnionHasher::H6(ref mut hasher) => {
-                <Alloc as Allocator<u16>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.num,
-                        <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                    ),
-                );
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut hasher.num));
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets));
             }
             &mut UnionHasher::H9(ref mut hasher) => {
-                <Alloc as Allocator<u16>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.num_,
-                        <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                    ),
-                );
-                <Alloc as Allocator<u32>>::free_cell(
-                    alloc,
-                    core::mem::replace(
-                        &mut hasher.buckets_,
-                        <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-                    ),
-                );
+                <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut hasher.num_));
+                <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut hasher.buckets_));
             }
             &mut UnionHasher::H10(ref mut hasher) => {
                 hasher.free(alloc);
@@ -2585,8 +2503,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                 new_commands_count += 1;
                 InitCommand(
                     {
-                        let (mut _old, new_commands) =
-                            core::mem::replace(&mut commands, &mut []).split_at_mut(1);
+                        let (mut _old, new_commands) = take(&mut commands).split_at_mut(1);
                         commands = new_commands;
                         &mut _old[0]
                     },

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
+
 use super::super::alloc;
 use super::super::alloc::Allocator;
 use super::super::alloc::SliceWrapper;
-use core;
+use std::mem::take;
+
 pub struct BlockSplit<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> {
     pub num_types: usize,
     pub num_blocks: usize,
@@ -20,20 +22,8 @@ impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> BlockSplit<Alloc> {
         }
     }
     pub fn destroy(&mut self, m: &mut Alloc) {
-        <Alloc as Allocator<u8>>::free_cell(
-            m,
-            core::mem::replace(
-                &mut self.types,
-                <Alloc as Allocator<u8>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<u32>>::free_cell(
-            m,
-            core::mem::replace(
-                &mut self.lengths,
-                <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<u8>>::free_cell(m, take(&mut self.types));
+        <Alloc as Allocator<u32>>::free_cell(m, take(&mut self.lengths));
         self.num_blocks = 0;
         self.num_types = 0;
     }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -9,6 +9,7 @@ use super::util::floatX;
 use super::{s16, v8};
 #[cfg(feature = "std")]
 use std::io::Write;
+use std::mem::take;
 use VERSION;
 
 use super::block_split::BlockSplit;
@@ -184,20 +185,8 @@ impl<'a, Alloc: BrotliAlloc> CommandQueue<'a, Alloc> {
         self.entropy_tally_scratch.free(&mut self.mc);
         self.entropy_pyramid.free(&mut self.mc);
         self.context_map_entropy.free(&mut self.mc);
-        <Alloc as Allocator<StaticCommand>>::free_cell(
-            self.mc,
-            core::mem::replace(
-                &mut self.queue,
-                <Alloc as Allocator<StaticCommand>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<u8>>::free_cell(
-            self.mc,
-            core::mem::replace(
-                &mut self.best_strides_per_block_type,
-                <Alloc as Allocator<u8>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<StaticCommand>>::free_cell(self.mc, take(&mut self.queue));
+        <Alloc as Allocator<u8>>::free_cell(self.mc, take(&mut self.best_strides_per_block_type));
         if self.overfull {
             return Err(());
         }
@@ -1201,10 +1190,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
             count_limit = count_limit.wrapping_mul(2u32);
         }
         {
-            m.free_cell(core::mem::replace(
-                &mut tree,
-                AllocHT::AllocatedMemory::default(),
-            ));
+            m.free_cell(take(&mut tree));
         }
     }
     BrotliConvertBitDepthsToSymbols(depth, length as usize, bits);
@@ -1365,45 +1351,24 @@ impl<
         self.literal_split.destroy(alloc);
         self.command_split.destroy(alloc);
         self.distance_split.destroy(alloc);
-        <Alloc as Allocator<u32>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.literal_context_map,
-                <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut self.literal_context_map));
         self.literal_context_map_size = 0;
-        <Alloc as Allocator<u32>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.distance_context_map,
-                <Alloc as Allocator<u32>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<u32>>::free_cell(alloc, take(&mut self.distance_context_map));
         self.distance_context_map_size = 0;
         <Alloc as Allocator<HistogramLiteral>>::free_cell(
             alloc,
-            core::mem::replace(
-                &mut self.literal_histograms,
-                <Alloc as Allocator<HistogramLiteral>>::AllocatedMemory::default(),
-            ),
+            take(&mut self.literal_histograms),
         );
 
         self.literal_histograms_size = 0;
         <Alloc as Allocator<HistogramCommand>>::free_cell(
             alloc,
-            core::mem::replace(
-                &mut self.command_histograms,
-                <Alloc as Allocator<HistogramCommand>>::AllocatedMemory::default(),
-            ),
+            take(&mut self.command_histograms),
         );
         self.command_histograms_size = 0;
         <Alloc as Allocator<HistogramDistance>>::free_cell(
             alloc,
-            core::mem::replace(
-                &mut self.distance_histograms,
-                <Alloc as Allocator<HistogramDistance>>::AllocatedMemory::default(),
-            ),
+            take(&mut self.distance_histograms),
         );
         self.distance_histograms_size = 0;
     }
@@ -2385,20 +2350,8 @@ fn CleanupBlockEncoder<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
     m: &mut Alloc,
     xself: &mut BlockEncoder<Alloc>,
 ) {
-    <Alloc as Allocator<u8>>::free_cell(
-        m,
-        core::mem::replace(
-            &mut (*xself).depths_,
-            <Alloc as Allocator<u8>>::AllocatedMemory::default(),
-        ),
-    );
-    <Alloc as Allocator<u16>>::free_cell(
-        m,
-        core::mem::replace(
-            &mut (*xself).bits_,
-            <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-        ),
-    );
+    <Alloc as Allocator<u8>>::free_cell(m, take(&mut (*xself).depths_));
+    <Alloc as Allocator<u16>>::free_cell(m, take(&mut (*xself).bits_));
 }
 
 pub fn JumpToByteBoundary(storage_ix: &mut usize, storage: &mut [u8]) {
@@ -2575,13 +2528,7 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
         storage,
     );
     {
-        <Alloc as Allocator<HuffmanTree>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut tree,
-                <Alloc as Allocator<HuffmanTree>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<HuffmanTree>>::free_cell(alloc, take(&mut tree));
     }
     i = 0usize;
     while i < n_commands {

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -7,6 +7,7 @@ pub use super::ir_interpret::{push_base, Context, IRInterpreter};
 use super::util::{floatX, FastLog2u16};
 use super::weights::{Weights, BLEND_FIXED_POINT_PRECISION};
 use core;
+use std::mem::take;
 
 const DEFAULT_CM_SPEED_INDEX: usize = 8;
 const NUM_SPEEDS_TO_TRY: usize = 16;
@@ -424,20 +425,8 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
         ret
     }
     pub fn free(&mut self, alloc: &mut Alloc) {
-        <Alloc as Allocator<u16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.cm_priors,
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<u16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.stride_priors,
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut self.cm_priors));
+        <Alloc as Allocator<u16>>::free_cell(alloc, take(&mut self.stride_priors));
     }
     fn update_cost_base(
         &mut self,

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -4,8 +4,10 @@ use super::input_pair::{InputPair, InputReference};
 use super::interface;
 use super::util::FastLog2;
 use core::cmp;
-use core::mem;
+
 use core::ops::{Index, IndexMut, Range};
+use std::mem::take;
+
 // float32 doesn't have enough resolution for blocks of data more than 3.5 megs
 pub type floatY = f64;
 // the cost of storing a particular population of data including the approx
@@ -43,10 +45,7 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyBucketPopulation<AllocU32> {
         }
     }
     pub fn free(&mut self, m32: &mut AllocU32) {
-        m32.free_cell(mem::replace(
-            &mut self.bucket_populations,
-            AllocU32::AllocatedMemory::default(),
-        ));
+        m32.free_cell(take(&mut self.bucket_populations));
     }
     fn clone_from(&mut self, other: &EntropyBucketPopulation<AllocU32>) {
         self.bucket_populations
@@ -883,10 +882,7 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyTally<AllocU32> {
     }
     pub fn free(&mut self, m32: &mut AllocU32) {
         for item in self.pop.iter_mut() {
-            m32.free_cell(mem::replace(
-                &mut item.bucket_populations,
-                AllocU32::AllocatedMemory::default(),
-            ))
+            m32.free_cell(take(&mut item.bucket_populations))
         }
     }
     pub fn is_free(&mut self) -> bool {

--- a/src/enc/fixed_queue.rs
+++ b/src/enc/fixed_queue.rs
@@ -42,7 +42,7 @@ impl<T: Sized> FixedQueue<T> {
             return None;
         }
         let index = self.start % self.data.len();
-        let ret = core::mem::replace(&mut self.data[index], None);
+        let ret = self.data[index].take();
         self.start += 1;
         self.size -= 1;
         ret
@@ -58,8 +58,8 @@ impl<T: Sized> FixedQueue<T> {
             if f(&self.data[(self.start + index) % self.data.len()]) {
                 let start_index = self.start % self.data.len();
                 let target_index = (self.start + index) % self.data.len();
-                let ret = core::mem::replace(&mut self.data[target_index], None);
-                let replace = core::mem::replace(&mut self.data[start_index], None);
+                let ret = self.data[target_index].take();
+                let replace = self.data[start_index].take();
                 let is_none = core::mem::replace(&mut self.data[target_index], replace);
                 assert!(is_none.is_none());
                 self.start += 1;

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -10,6 +10,7 @@ use super::{s16, v8};
 use core;
 #[cfg(feature = "simd")]
 use packed_simd_2::IntoBits;
+use std::mem::take;
 // the high nibble, followed by the low nibbles
 pub const CONTEXT_MAP_PRIOR_SIZE: usize = 256 * 17;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * 2;
@@ -580,70 +581,16 @@ impl<'a, Alloc: alloc::Allocator<s16> + alloc::Allocator<u32> + alloc::Allocator
         self.context_map.set_mixing_values(&bitmask);
     }
     pub fn free(&mut self, alloc: &mut Alloc) {
-        <Alloc as Allocator<v8>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.score,
-                <Alloc as Allocator<v8>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.cm_priors,
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.slow_cm_priors,
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.fast_cm_priors,
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.stride_priors[0],
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.stride_priors[1],
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.stride_priors[2],
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.stride_priors[3],
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<v8>>::free_cell(alloc, take(&mut self.score));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.cm_priors));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.slow_cm_priors));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.fast_cm_priors));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.stride_priors[0]));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.stride_priors[1]));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.stride_priors[2]));
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.stride_priors[3]));
         //<Alloc as Allocator<s16>>::free_cell(alloc, core::mem::replace(&mut self.stride_priors[4], <Alloc as Allocator<s16>>::AllocatedMemory::default()));
-        <Alloc as Allocator<s16>>::free_cell(
-            alloc,
-            core::mem::replace(
-                &mut self.adv_priors,
-                <Alloc as Allocator<s16>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<s16>>::free_cell(alloc, take(&mut self.adv_priors));
     }
 
     pub fn take_prediction_mode(

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -7,6 +7,8 @@ use super::ir_interpret::{push_base, IRInterpreter};
 use super::prior_eval::DEFAULT_SPEED;
 use super::util::{floatX, FastLog2u16};
 use core;
+use std::mem::take;
+
 const NIBBLE_PRIOR_SIZE: usize = 16;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * NIBBLE_PRIOR_SIZE * 2;
 
@@ -245,21 +247,9 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
     for StrideEval<'a, Alloc>
 {
     fn drop(&mut self) {
-        <Alloc as Allocator<floatX>>::free_cell(
-            &mut self.alloc,
-            core::mem::replace(
-                &mut self.score,
-                <Alloc as Allocator<floatX>>::AllocatedMemory::default(),
-            ),
-        );
+        <Alloc as Allocator<floatX>>::free_cell(&mut self.alloc, take(&mut self.score));
         for i in 0..8 {
-            <Alloc as Allocator<u16>>::free_cell(
-                &mut self.alloc,
-                core::mem::replace(
-                    &mut self.stride_priors[i],
-                    <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                ),
-            );
+            <Alloc as Allocator<u16>>::free_cell(&mut self.alloc, take(&mut self.stride_priors[i]));
         }
     }
 }

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -99,7 +99,7 @@ impl<
             cvar.notify_all();
         }
         for thread_handle in self.join.iter_mut() {
-            if let Some(th) = mem::replace(thread_handle, None) {
+            if let Some(th) = thread_handle.take() {
                 th.join().unwrap();
             }
         }

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -13,7 +13,7 @@ pub use alloc_stdlib::StandardAlloc;
 use brotli_decompressor::CustomWrite;
 #[cfg(feature = "std")]
 pub use brotli_decompressor::{IntoIoWriter, IoWriterWrapper};
-use core;
+
 #[cfg(feature = "std")]
 use std::io;
 
@@ -231,7 +231,7 @@ impl<ErrType, W: CustomWrite<ErrType>, BufferType: SliceWrapperMut<u8>, Alloc: B
             Ok(_) => {}
             Err(_) => {}
         }
-        core::mem::replace(&mut self.output, None).unwrap()
+        self.output.take().unwrap()
     }
 }
 


### PR DESCRIPTION
Auto-fixed clippy::mem_replace_with_default, mem_replace_option_with_none

This was fully automatic, but then I search/replaced all `std::mem::take(...)` with `take(...)`, and added the `use` statement because it replaced `core::mem` with `std::mem`, and we may need to use `core` in a `no-std` env

```sh
cargo clippy --fix -- -A clippy::all \
   -W clippy::mem_replace_with_default \
   -W clippy::mem_replace_option_with_none
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/mem_replace_with_default
* https://rust-lang.github.io/rust-clippy/master/index.html#/mem_replace_option_with_none