### PR TITLE
Auto-fixed clippy::needless_late_init

### DIFF
--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -477,8 +477,8 @@ where
             }
             {
                 let cur_len: usize = core::cmp::min(best_len_left, best_len_right);
-                let len: usize;
-                len = cur_len.wrapping_add(FindMatchLengthWithLimit(
+
+                let len: usize = cur_len.wrapping_add(FindMatchLengthWithLimit(
                     &data[(cur_ix_masked.wrapping_add(cur_len) as (usize))..],
                     &data[(prev_ix_masked.wrapping_add(cur_len) as (usize))..],
                     max_length.wrapping_sub(cur_len),

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -904,9 +904,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                             let dist_code: usize = dist.wrapping_add(16usize).wrapping_sub(1usize);
                             let mut dist_symbol: u16 = 0;
                             let mut distextra: u32 = 0;
-                            let distnumextra: u32;
-                            let dist_cost: floatX;
-                            let max_match_len: usize;
+
                             PrefixEncodeCopyDistance(
                                 dist_code,
                                 (*params).dist.num_direct_distance_codes as (usize),
@@ -914,14 +912,14 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                 &mut dist_symbol,
                                 &mut distextra,
                             );
-                            distnumextra = u32::from(dist_symbol) >> 10;
-                            dist_cost = base_cost
+                            let distnumextra: u32 = u32::from(dist_symbol) >> 10;
+                            let dist_cost: floatX = base_cost
                                 + distnumextra as (floatX)
                                 + ZopfliCostModelGetDistanceCost(
                                     model,
                                     (dist_symbol as (i32) & 0x3ff) as (usize),
                                 );
-                            max_match_len = BackwardMatchLength(&mut match_);
+                            let max_match_len: usize = BackwardMatchLength(&mut match_);
                             if len < max_match_len
                                 && (is_dictionary_match != 0 || max_match_len > max_zopfli_len)
                             {
@@ -1211,8 +1209,7 @@ pub fn BrotliCreateZopfliBackwardReferences<
 fn SetCost(histogram: &[u32], histogram_size: usize, literal_histogram: i32, cost: &mut [floatX]) {
     let mut sum: u64 = 0;
     let mut missing_symbol_sum: u64;
-    let log2sum: floatX;
-    let missing_symbol_cost: floatX;
+
     let mut i: usize;
     i = 0usize;
     while i < histogram_size {
@@ -1221,7 +1218,7 @@ fn SetCost(histogram: &[u32], histogram_size: usize, literal_histogram: i32, cos
         }
         i = i.wrapping_add(1 as (usize));
     }
-    log2sum = FastLog2(sum) as (floatX);
+    let log2sum: floatX = FastLog2(sum) as (floatX);
     missing_symbol_sum = sum;
     if literal_histogram == 0 {
         i = 0usize;
@@ -1234,7 +1231,8 @@ fn SetCost(histogram: &[u32], histogram_size: usize, literal_histogram: i32, cos
             i = i.wrapping_add(1 as (usize));
         }
     }
-    missing_symbol_cost = FastLog2f64(missing_symbol_sum) as (floatX) + 2i32 as (floatX);
+    let missing_symbol_cost: floatX =
+        FastLog2f64(missing_symbol_sum) as (floatX) + 2i32 as (floatX);
     i = 0usize;
     while i < histogram_size {
         'continue56: loop {
@@ -1485,10 +1483,9 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     };
     let mut cur_match_pos: usize = 0usize;
     let mut i: usize;
-    let orig_num_literals: usize;
-    let orig_last_insert_len: usize;
+
     let mut orig_dist_cache = [0i32; 4];
-    let orig_num_commands: usize;
+
     let mut model: ZopfliCostModel<Alloc>;
     let mut nodes: <Alloc as Allocator<ZopfliNode>>::AllocatedMemory;
     let mut matches: <Alloc as Allocator<u64>>::AllocatedMemory = if matches_size > 0usize {
@@ -1504,8 +1501,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
             let pos: usize = position.wrapping_add(i);
             let max_distance: usize = brotli_min_size_t(pos, max_backward_limit);
             let max_length: usize = num_bytes.wrapping_sub(i);
-            let num_found_matches: usize;
-            let cur_match_end: usize;
+
             let mut j: usize;
             {
                 if matches_size
@@ -1560,7 +1556,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
             if !(0i32 == 0) {
                 return;
             }
-            num_found_matches = FindAllMatchesH10(
+            let num_found_matches: usize = FindAllMatchesH10(
                 hasher,
                 dictionary, //&(*params).dictionary ,
                 ringbuffer,
@@ -1572,7 +1568,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                 params,
                 &mut matches.slice_mut()[(cur_match_pos.wrapping_add(shadow_matches) as (usize))..],
             );
-            cur_match_end = cur_match_pos.wrapping_add(num_found_matches);
+            let cur_match_end: usize = cur_match_pos.wrapping_add(num_found_matches);
             j = cur_match_pos;
             while j.wrapping_add(1usize) < cur_match_end {
                 {}
@@ -1616,8 +1612,8 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
         }
         i = i.wrapping_add(1 as (usize));
     }
-    orig_num_literals = *num_literals;
-    orig_last_insert_len = *last_insert_len;
+    let orig_num_literals: usize = *num_literals;
+    let orig_last_insert_len: usize = *last_insert_len;
     for (i, j) in orig_dist_cache
         .split_at_mut(4)
         .0
@@ -1626,7 +1622,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     {
         *i = *j;
     }
-    orig_num_commands = *num_commands;
+    let orig_num_commands: usize = *num_commands;
     nodes = if num_bytes.wrapping_add(1usize) > 0usize {
         <Alloc as Allocator<ZopfliNode>>::alloc_cell(alloc, num_bytes.wrapping_add(1))
     } else {

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -397,11 +397,9 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         }
         let bucket_sweep = self.buckets_.BUCKET_SWEEP();
         if bucket_sweep == 1i32 {
-            let backward: usize;
-            let len: usize;
             prev_ix = (*self).buckets_.slice()[key as (usize)] as (usize);
             (*self).buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
-            backward = cur_ix.wrapping_sub(prev_ix);
+            let backward: usize = cur_ix.wrapping_sub(prev_ix);
             prev_ix = prev_ix & ring_buffer_mask as (u32) as (usize);
             if compare_char != data[(prev_ix.wrapping_add(best_len_in) as (usize))] as (i32) {
                 return false;
@@ -409,7 +407,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
             if backward == 0usize || backward > max_backward {
                 return false;
             }
-            len = FindMatchLengthWithLimitMin4(
+            let len: usize = FindMatchLengthWithLimitMin4(
                 &data[(prev_ix as (usize))..],
                 &data[(cur_ix_masked as (usize))..],
                 max_length,
@@ -1908,19 +1906,16 @@ fn TestStaticDictionaryItem(
     h9_opts: H9Opts,
     out: &mut HasherSearchResult,
 ) -> i32 {
-    let len: usize;
-    let dist: usize;
-    let offset: usize;
-    let matchlen: usize;
     let backward: usize;
-    let score: u64;
-    len = item & 0x1fusize;
-    dist = item >> 5i32;
-    offset = ((*dictionary).offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(dist));
+
+    let len: usize = item & 0x1fusize;
+    let dist: usize = item >> 5i32;
+    let offset: usize =
+        ((*dictionary).offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(dist));
     if len > max_length {
         return 0i32;
     }
-    matchlen = FindMatchLengthWithLimit(data, &(*dictionary).data[offset..], len);
+    let matchlen: usize = FindMatchLengthWithLimit(data, &(*dictionary).data[offset..], len);
     if matchlen.wrapping_add(kCutoffTransformsCount as usize) <= len || matchlen == 0usize {
         return 0i32;
     }
@@ -1937,7 +1932,7 @@ fn TestStaticDictionaryItem(
     if backward > max_distance {
         return 0i32;
     }
-    score = BackwardReferenceScore(matchlen, backward, h9_opts);
+    let score: u64 = BackwardReferenceScore(matchlen, backward, h9_opts);
     if score < (*out).score {
         return 0i32;
     }
@@ -2518,7 +2513,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
             'break6: loop {
                 'continue7: loop {
                     let cost_diff_lazy: u64 = 175;
-                    let is_match_found: bool;
+
                     let mut sr2 = HasherSearchResult {
                         len: 0,
                         len_x_code: 0,
@@ -2535,7 +2530,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                     sr2.score = kMinScore;
                     max_distance =
                         brotli_min_size_t(position.wrapping_add(1usize), max_backward_limit);
-                    is_match_found = hasher.FindLongestMatch(
+                    let is_match_found: bool = hasher.FindLongestMatch(
                         dictionary,
                         dictionary_hash,
                         ringbuffer,

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -289,8 +289,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
     }
     if count == 4i32 {
         let mut histo: [u32; 4] = [0; 4];
-        let h23: u32;
-        let histomax: u32;
+
         i = 0usize;
         while i < 4usize {
             {
@@ -316,8 +315,8 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
             }
             i = i.wrapping_add(1 as (usize));
         }
-        h23 = histo[2usize].wrapping_add(histo[3usize]);
-        histomax = brotli_max_uint32_t(h23, histo[0usize]);
+        let h23: u32 = histo[2usize].wrapping_add(histo[3usize]);
+        let histomax: u32 = brotli_max_uint32_t(h23, histo[0usize]);
         return kFourSymbolHistogramCost
             + (3u32).wrapping_mul(h23) as super::util::floatX
             + (2u32).wrapping_mul(histo[0usize].wrapping_add(histo[1usize]))

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -565,7 +565,7 @@ fn ClusterBlocks<
     let mut pairs = <Alloc as Allocator<HistogramPair>>::alloc_cell(alloc, pairs_capacity);
     let mut pos: usize = 0usize;
     let mut clusters: <Alloc as Allocator<u32>>::AllocatedMemory;
-    let num_final_clusters: usize;
+
     static kInvalidIndex: u32 = !(0u32);
     let mut i: usize;
     let mut sizes: [u32; 64] = [0; 64];
@@ -598,7 +598,7 @@ fn ClusterBlocks<
     while i < num_blocks {
         {
             let num_to_combine: usize = brotli_min_size_t(num_blocks.wrapping_sub(i), 64usize);
-            let num_new_clusters: usize;
+
             let mut j: usize;
             j = 0usize;
             while j < num_to_combine {
@@ -632,7 +632,7 @@ fn ClusterBlocks<
                 }
                 j = j.wrapping_add(1 as (usize));
             }
-            num_new_clusters = BrotliHistogramCombine(
+            let num_new_clusters: usize = BrotliHistogramCombine(
                 histograms.slice_mut(),
                 &mut sizes[..],
                 &mut symbols[..],
@@ -743,7 +743,7 @@ fn ClusterBlocks<
         *item = i as u32;
         i = i.wrapping_add(1 as (usize));
     }
-    num_final_clusters = BrotliHistogramCombine(
+    let num_final_clusters: usize = BrotliHistogramCombine(
         all_histograms.slice_mut(),
         cluster_size.slice_mut(),
         histogram_symbols.slice_mut(),

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1147,12 +1147,12 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                 }
                 {
                     let n: i32 = node_index as (i32);
-                    let sentinel: HuffmanTree;
+
                     let mut i: i32 = 0i32;
                     let mut j: i32 = n + 1i32;
                     let mut k: i32;
                     SortHuffmanTreeItems(tree.slice_mut(), n as (usize), SimpleSortHuffmanTree {});
-                    sentinel = NewHuffmanTree(!(0u32), -1i16, -1i16);
+                    let sentinel: HuffmanTree = NewHuffmanTree(!(0u32), -1i16, -1i16);
                     tree.slice_mut()[(node_index.wrapping_add(1u32) as (usize))] = sentinel.clone();
                     tree.slice_mut()[(node_index as (usize))] = sentinel.clone();
                     node_index = node_index.wrapping_add(2u32);

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -112,10 +112,10 @@ fn BrotliCompareAndPushToQueue<
                     (pairs[0i32 as (usize)]).cost_diff,
                 )
             };
-            let cost_combo: super::util::floatX;
+
             let mut combo: HistogramType = out[idx1 as usize].clone();
             HistogramAddHistogram(&mut combo, &out[idx2 as usize]);
-            cost_combo = BrotliPopulationCost(&combo, scratch_space);
+            let cost_combo: super::util::floatX = BrotliPopulationCost(&combo, scratch_space);
             if cost_combo < threshold - p.cost_diff {
                 p.cost_combo = cost_combo;
                 is_good_pair = 1i32;
@@ -186,8 +186,6 @@ pub fn BrotliHistogramCombine<
         }
     }
     while num_clusters > min_cluster_size {
-        let best_idx1: u32;
-        let best_idx2: u32;
         let mut i: usize;
         if (pairs[(0usize)]).cost_diff >= cost_diff_threshold {
             cost_diff_threshold = 1e38 as super::util::floatX;
@@ -199,8 +197,8 @@ pub fn BrotliHistogramCombine<
             }
         }
         /* Take the best pair from the top of heap. */
-        best_idx1 = (pairs[(0usize)]).idx1;
-        best_idx2 = (pairs[(0usize)]).idx2;
+        let best_idx1: u32 = (pairs[(0usize)]).idx1;
+        let best_idx2: u32 = (pairs[(0usize)]).idx2;
         HistogramSelfAddHistogram(&mut out, (best_idx1 as (usize)), (best_idx2 as (usize)));
         (out[(best_idx1 as (usize))]).set_bit_cost((pairs[(0usize)]).cost_combo);
         {
@@ -508,7 +506,7 @@ pub fn BrotliClusterHistograms<
         {
             let num_to_combine: usize =
                 brotli_min_size_t(in_size.wrapping_sub(i), max_input_histograms);
-            let num_new_clusters: usize;
+
             let mut j: usize;
             j = 0usize;
             while j < num_to_combine {
@@ -518,7 +516,7 @@ pub fn BrotliClusterHistograms<
                 }
                 j = j.wrapping_add(1 as (usize));
             }
-            num_new_clusters = BrotliHistogramCombine(
+            let num_new_clusters: usize = BrotliHistogramCombine(
                 out,
                 cluster_size.slice_mut(),
                 &mut histogram_symbols[(i as (usize))..],

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -127,8 +127,8 @@ fn compute_combined_cost(
         if stride_max[i] == 0 {
             assert!(stride_max[i] != 0);
         }
-        let w;
-        w = (1 << (BLEND_FIXED_POINT_PRECISION - 2)); // a quarter of weight to stride
+
+        let w = (1 << (BLEND_FIXED_POINT_PRECISION - 2)); // a quarter of weight to stride
         let combined_pdf = w * u32::from(stride_pdf[i])
             + ((1 << BLEND_FIXED_POINT_PRECISION) - w) * u32::from(cm_pdf);
         let combined_max = w * u32::from(stride_max[i])

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1532,9 +1532,8 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
     } as (usize))] = 0x3i32 as (u8);
     while size > 0usize {
         let mut nibbles: u32 = 0u32;
-        let chunk_size: u32;
-        let bits: u32;
-        chunk_size = if size > (1u32 << 24i32) as (usize) {
+
+        let chunk_size: u32 = if size > (1u32 << 24i32) as (usize) {
             1u32 << 24i32
         } else {
             size as (u32)
@@ -1546,7 +1545,7 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
                 1i32
             } as (u32);
         }
-        bits = nibbles << 1i32
+        let bits: u32 = nibbles << 1i32
             | chunk_size.wrapping_sub(1u32) << 3i32
             | 1u32 << (19u32).wrapping_add((4u32).wrapping_mul(nibbles));
         output[({
@@ -1905,7 +1904,7 @@ fn ChooseContextMap(
     ];
     let mut monogram_histo: [u32; 3] = [0u32, 0u32, 0u32];
     let mut two_prefix_histo: [u32; 6] = [0u32, 0u32, 0u32, 0u32, 0u32, 0u32];
-    let total: usize;
+
     let mut i: usize;
     let mut dummy: usize = 0;
     let mut entropy: [super::util::floatX; 4] = [0.0 as super::util::floatX; 4];
@@ -1942,7 +1941,7 @@ fn ChooseContextMap(
         }
         i = i.wrapping_add(1 as (usize));
     }
-    total = monogram_histo[0usize]
+    let total: usize = monogram_histo[0usize]
         .wrapping_add(monogram_histo[1usize])
         .wrapping_add(monogram_histo[2usize]) as (usize);
     0i32;
@@ -2166,8 +2165,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
         assert_eq!(params.catable, false); // Sanitize Params senforces this constraint
     }
     let wrapped_last_flush_pos: u32 = WrapPosition(last_flush_pos);
-    let last_bytes: u16;
-    let last_bytes_bits: u8;
+
     let literal_context_lut = BROTLI_CONTEXT_LUT(literal_context_mode);
     let mut block_params = params.clone();
     if bytes == 0usize {
@@ -2205,9 +2203,9 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
         return;
     }
     let saved_byte_location = (*storage_ix) >> 3;
-    last_bytes =
+    let last_bytes: u16 =
         ((storage[saved_byte_location + 1] as u16) << 8) | storage[saved_byte_location] as u16;
-    last_bytes_bits = *storage_ix as u8;
+    let last_bytes_bits: u8 = *storage_ix as u8;
     /*if params.dist.num_direct_distance_codes != 0 ||
                       params.dist.distance_postfix_bits != 0 {
       RecomputeDistancePrefixes(commands,
@@ -2364,7 +2362,6 @@ fn ChooseDistanceParams(params: &mut BrotliEncoderParams) {
     let mut distance_postfix_bits = 0u32;
 
     if params.quality >= 4 {
-        let ndirect_msb;
         if params.mode == BrotliEncoderMode::BROTLI_MODE_FONT {
             distance_postfix_bits = 1;
             num_direct_distance_codes = 12;
@@ -2372,7 +2369,7 @@ fn ChooseDistanceParams(params: &mut BrotliEncoderParams) {
             distance_postfix_bits = params.dist.distance_postfix_bits;
             num_direct_distance_codes = params.dist.num_direct_distance_codes;
         }
-        ndirect_msb = (num_direct_distance_codes >> distance_postfix_bits) & 0x0f;
+        let ndirect_msb = (num_direct_distance_codes >> distance_postfix_bits) & 0x0f;
         if distance_postfix_bits > BROTLI_MAX_NPOSTFIX as u32
             || num_direct_distance_codes > BROTLI_MAX_NDIRECT as u32
             || (ndirect_msb << distance_postfix_bits) != num_direct_distance_codes
@@ -2523,7 +2520,6 @@ where
     if (*s).params.quality == 0i32 || (*s).params.quality == 1i32 {
         let mut table_size: usize = 0;
         {
-            let table: &mut [i32];
             if delta == 0 && (is_last == 0) {
                 *out_size = catable_header_size;
                 return 1i32;
@@ -2534,7 +2530,8 @@ where
             //(*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
             //        (*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
 
-            table = GetHashTable!(s, (*s).params.quality, bytes as (usize), &mut table_size);
+            let table: &mut [i32] =
+                GetHashTable!(s, (*s).params.quality, bytes as (usize), &mut table_size);
 
             if (*s).params.quality == 0i32 {
                 BrotliCompressFragmentFast(
@@ -3019,7 +3016,7 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             let storage: &mut [u8];
             let mut storage_ix: usize = (*s).last_bytes_bits_ as (usize);
             let mut table_size: usize = 0;
-            let table: &mut [i32];
+
             if force_flush != 0 && (block_size == 0usize) {
                 (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
                 {
@@ -3037,7 +3034,8 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             }
             storage[(0usize)] = (*s).last_bytes_ as u8;
             storage[(1usize)] = ((*s).last_bytes_ >> 8) as u8;
-            table = GetHashTable!(s, (*s).params.quality, block_size, &mut table_size);
+            let table: &mut [i32] =
+                GetHashTable!(s, (*s).params.quality, block_size, &mut table_size);
             if (*s).params.quality == 0i32 {
                 BrotliCompressFragmentFast(
                     &mut s.m8,
@@ -3244,10 +3242,11 @@ pub fn BrotliEncoderCompressStream<
                 } else {
                     0i32
                 };
-                let result: i32;
+
                 UpdateSizeHint(s, *available_in);
                 let mut avail_out = (*s).available_out_;
-                result = EncodeData(s, is_last, force_flush, &mut avail_out, metablock_callback);
+                let result: i32 =
+                    EncodeData(s, is_last, force_flush, &mut avail_out, metablock_callback);
                 (*s).available_out_ = avail_out;
                 //this function set next_out to &storage[0]
                 if result == 0 {

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -517,9 +517,8 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
             j = (*cmd).insert_len_ as (usize);
             while j != 0usize {
                 {
-                    let context: usize;
                     BlockSplitIteratorNext(&mut literal_it);
-                    context = if context_modes.len() != 0 {
+                    let context: usize = if context_modes.len() != 0 {
                         (literal_it.type_ << 6i32).wrapping_add(Context(
                             prev_byte,
                             prev_byte2,
@@ -544,9 +543,8 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
                 prev_byte2 = ringbuffer[((pos.wrapping_sub(2usize) & mask) as (usize))];
                 prev_byte = ringbuffer[((pos.wrapping_sub(1usize) & mask) as (usize))];
                 if (*cmd).cmd_prefix_ as (i32) >= 128i32 {
-                    let context: usize;
                     BlockSplitIteratorNext(&mut dist_it);
-                    context = (dist_it.type_ << 2i32)
+                    let context: usize = (dist_it.type_ << 2i32)
                         .wrapping_add(CommandDistanceContext(cmd) as (usize));
                     HistogramAddItem(
                         &mut copy_dist_histograms[(context as (usize))],

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -152,8 +152,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
     let mut literal_histograms: <Alloc as Allocator<HistogramLiteral>>::AllocatedMemory;
     let mut literal_context_modes: <Alloc as Allocator<ContextType>>::AllocatedMemory =
         <Alloc as Allocator<ContextType>>::AllocatedMemory::default();
-    let literal_histograms_size: usize;
-    let distance_histograms_size: usize;
+
     let mut i: usize;
     let mut literal_context_multiplier: usize = 1usize;
     let mut ndirect_msb: u32 = 0;
@@ -166,7 +165,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         for npostfix in 0..(BROTLI_MAX_NPOSTFIX + 1) {
             while ndirect_msb < 16 {
                 let ndirect = ndirect_msb << npostfix;
-                let skip: bool;
+
                 let mut dist_cost: f64 = 0.0;
                 BrotliInitDistanceParams(&mut new_params, npostfix as u32, ndirect as u32);
                 if npostfix as u32 == orig_params.dist.distance_postfix_bits
@@ -174,7 +173,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
                 {
                     check_orig = false;
                 }
-                skip = !ComputeDistanceCost(
+                let skip: bool = !ComputeDistanceCost(
                     cmds,
                     num_commands,
                     &orig_params.dist,
@@ -234,13 +233,13 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
             *item = literal_context_mode;
         }
     }
-    literal_histograms_size = (*mb)
+    let literal_histograms_size: usize = (*mb)
         .literal_split
         .num_types
         .wrapping_mul(literal_context_multiplier);
     literal_histograms =
         <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, literal_histograms_size);
-    distance_histograms_size = (*mb).distance_split.num_types << 2i32;
+    let distance_histograms_size: usize = (*mb).distance_split.num_types << 2i32;
     distance_histograms =
         <Alloc as Allocator<HistogramDistance>>::alloc_cell(alloc, distance_histograms_size);
     (*mb).command_histograms_size = (*mb).command_split.num_types;
@@ -496,7 +495,7 @@ fn InitContextBlockSplitter<
     let max_num_blocks: usize = num_symbols
         .wrapping_div(min_block_size)
         .wrapping_add(1usize);
-    let max_num_types: usize;
+
     assert!(num_contexts <= BROTLI_MAX_STATIC_CONTEXTS);
     let mut xself = ContextBlockSplitter {
         alphabet_size_: alphabet_size,
@@ -513,7 +512,8 @@ fn InitContextBlockSplitter<
         last_histogram_ix_: [0; 2],
         last_entropy_: [0.0 as super::util::floatX; 2 * BROTLI_MAX_STATIC_CONTEXTS],
     };
-    max_num_types = brotli_min_size_t(max_num_blocks, xself.max_block_types_.wrapping_add(1usize));
+    let max_num_types: usize =
+        brotli_min_size_t(max_num_blocks, xself.max_block_types_.wrapping_add(1usize));
     {
         if (*split).types.slice().len() < max_num_blocks {
             let mut _new_size: usize = if (*split).types.slice().len() == 0usize {

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -475,9 +475,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
             w.l = l as (u8);
             if w.transform() as (i32) == 0i32 {
                 let matchlen: usize = DictMatchLength(dictionary, data, id, l, max_length);
-                let s: &[u8];
+
                 let mut minlen: usize;
-                let maxlen: usize;
+
                 let mut len: usize;
                 if matchlen == l {
                     //eprint!("Adding match {} {} {}\n", w.len(), w.transform(), w.idx());
@@ -512,7 +512,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 if l > 9usize {
                     minlen = brotli_max_size_t(minlen, l.wrapping_sub(9usize));
                 }
-                maxlen = brotli_min_size_t(matchlen, l.wrapping_sub(2usize));
+                let maxlen: usize = brotli_min_size_t(matchlen, l.wrapping_sub(2usize));
                 len = minlen;
                 while len <= maxlen {
                     {
@@ -535,7 +535,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         continue;
                     }
                 }
-                s = &data.split_at(l as (usize)).1;
+                let s: &[u8] = &data.split_at(l as (usize)).1;
                 if s[(0usize)] as (i32) == b' ' as (i32) {
                     //eprint!("Edding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(id.wrapping_add(n), l.wrapping_add(1usize), l, matches);
@@ -1003,7 +1003,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 } else {
                     0i32
                 };
-                let s: &[u8];
+
                 if IsMatch(dictionary, w, data, max_length) == 0 {
                     {
                         continue;
@@ -1024,7 +1024,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         continue;
                     }
                 }
-                s = &data.split_at(l as (usize)).1;
+                let s: &[u8] = &data.split_at(l as (usize)).1;
                 if s[(0usize)] as (i32) == b' ' as (i32) {
                     //eprint!("AWdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
@@ -1178,7 +1178,6 @@ pub fn BrotliFindAllStaticDictionaryMatches(
             end = !(w.len() as (i32) & 0x80i32 == 0) as (i32);
             w.l = l as (u8);
             if w.transform() as (i32) == 0i32 {
-                let s: &[u8];
                 if IsMatch(
                     dictionary,
                     w,
@@ -1205,7 +1204,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         continue;
                     }
                 }
-                s = &data.split_at(l.wrapping_add(1usize) as (usize)).1;
+                let s: &[u8] = &data.split_at(l.wrapping_add(1usize) as (usize)).1;
                 if s[(0usize)] as (i32) == b' ' as (i32) {
                     //eprint!("BIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
@@ -1287,7 +1286,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 } else {
                     0i32
                 };
-                let s: &[u8];
+
                 if IsMatch(
                     dictionary,
                     w,
@@ -1314,7 +1313,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         continue;
                     }
                 }
-                s = &data.split_at(l.wrapping_add(1)).1;
+                let s: &[u8] = &data.split_at(l.wrapping_add(1)).1;
                 if s[(0usize)] as (i32) == b' ' as (i32) {
                     //eprint!("CBdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(


### PR DESCRIPTION
Do not merge before https://github.com/dropbox/rust-brotli/pull/109

This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::needless_late_init
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/needless_late_init