### PR TITLE
Auto-fixed clippy::needless_lifetimes

### DIFF
--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1845,8 +1845,8 @@ fn BuildAndStoreBlockSplitCode(
     }
 }
 
-fn BuildAndStoreBlockSwitchEntropyCodes<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
-    xself: &mut BlockEncoder<'a, Alloc>,
+fn BuildAndStoreBlockSwitchEntropyCodes<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
+    xself: &mut BlockEncoder<'_, Alloc>,
     tree: &mut [HuffmanTree],
     storage_ix: &mut usize,
     storage: &mut [u8],
@@ -2406,9 +2406,9 @@ pub fn JumpToByteBoundary(storage_ix: &mut usize, storage: &mut [u8]) {
     storage[((*storage_ix >> 3i32) as (usize))] = 0i32 as (u8);
 }
 
-pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
+pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
     alloc: &mut Alloc,
-    input: &'a [u8],
+    input: &[u8],
     start_pos: usize,
     length: usize,
     mask: usize,
@@ -2767,9 +2767,9 @@ fn StoreDataWithHuffmanCodes(
 }
 
 fn nop<'a>(_data: &[interface::Command<InputReference>]) {}
-pub fn BrotliStoreMetaBlockTrivial<'a, Alloc: BrotliAlloc, Cb>(
+pub fn BrotliStoreMetaBlockTrivial<Alloc: BrotliAlloc, Cb>(
     alloc: &mut Alloc,
-    input: &'a [u8],
+    input: &[u8],
     start_pos: usize,
     length: usize,
     mask: usize,
@@ -3187,12 +3187,12 @@ fn BrotliStoreUncompressedMetaBlockHeader(
     BrotliWriteBits(1, 1, storage_ix, storage);
 }
 
-fn InputPairFromMaskedInput<'a>(
-    input: &'a [u8],
+fn InputPairFromMaskedInput(
+    input: &[u8],
     position: usize,
     len: usize,
     mask: usize,
-) -> (&'a [u8], &'a [u8]) {
+) -> (&[u8], &[u8]) {
     let masked_pos: usize = position & mask;
     if masked_pos.wrapping_add(len) > mask.wrapping_add(1usize) {
         let len1: usize = mask.wrapping_add(1usize).wrapping_sub(masked_pos);

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -165,7 +165,7 @@ pub struct BucketPopIndex {
 
 impl<AllocU32: alloc::Allocator<u32>> Index<BucketPopIndex> for EntropyBucketPopulation<AllocU32> {
     type Output = u32;
-    fn index<'a>(&'a self, index: BucketPopIndex) -> &'a u32 {
+    fn index(&self, index: BucketPopIndex) -> &u32 {
         &self.bucket_populations.slice()
             [index.val as usize + index.six_bits as usize * 256 + index.stride as usize * 256 * 64]
     }
@@ -173,7 +173,7 @@ impl<AllocU32: alloc::Allocator<u32>> Index<BucketPopIndex> for EntropyBucketPop
 impl<AllocU32: alloc::Allocator<u32>> IndexMut<BucketPopIndex>
     for EntropyBucketPopulation<AllocU32>
 {
-    fn index_mut<'a>(&'a mut self, index: BucketPopIndex) -> &'a mut u32 {
+    fn index_mut(&mut self, index: BucketPopIndex) -> &mut u32 {
         &mut self.bucket_populations.slice_mut()
             [index.val as usize + index.six_bits as usize * 256 + index.stride as usize * 256 * 64]
     }

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -65,7 +65,7 @@ impl<'a> From<&'a InputReferenceMut<'a>> for InputReference<'a> {
 pub struct InputPair<'a>(pub InputReference<'a>, pub InputReference<'a>);
 
 impl<'a> core::cmp::PartialEq for InputPair<'a> {
-    fn eq<'b>(&self, other: &InputPair<'b>) -> bool {
+    fn eq(&self, other: &InputPair<'_>) -> bool {
         if self.0.len() + self.1.len() != other.0.len() + other.1.len() {
             return false;
         }

--- a/src/enc/ir_interpret.rs
+++ b/src/enc/ir_interpret.rs
@@ -22,9 +22,9 @@ pub trait IRInterpreter {
     );
 }
 
-pub fn push_base<'a, Interpreter: IRInterpreter>(
+pub fn push_base<Interpreter: IRInterpreter>(
     xself: &mut Interpreter,
-    val: interface::Command<InputReference<'a>>,
+    val: interface::Command<InputReference<'_>>,
 ) {
     match val {
         interface::Command::BlockSwitchCommand(_)


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::needless_lifetimes
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/needless_lifetimes