### PR TITLE
Auto-fixed clippy::manual_swap

### DIFF
--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -306,9 +306,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 while j < 4usize {
                     {
                         if histo[j] > histo[i] {
-                            let mut __brotli_swap_tmp: u32 = histo[j];
-                            histo[j] = histo[i];
-                            histo[i] = __brotli_swap_tmp;
+                            histo.swap(j, i);
                         }
                     }
                     j = j.wrapping_add(1 as (usize));

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1222,9 +1222,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                         if depth[(symbols[j as usize] as (usize))] as (i32)
                             < depth[(symbols[i as usize] as (usize)) as usize] as (i32)
                         {
-                            let brotli_swap_tmp: u64 = symbols[j as usize];
-                            symbols[j as usize] = symbols[i as usize];
-                            symbols[i as usize] = brotli_swap_tmp;
+                            symbols.swap(j as usize, i as usize);
                         }
                     }
                     j = j.wrapping_add(1);
@@ -1605,9 +1603,7 @@ fn StoreSimpleHuffmanTree(
                         if depths[(symbols[(j as (usize))] as (usize))] as (i32)
                             < depths[(symbols[(i as (usize))] as (usize))] as (i32)
                         {
-                            let mut __brotli_swap_tmp: usize = symbols[(j as (usize))];
-                            symbols[(j as (usize))] = symbols[(i as (usize))];
-                            symbols[(i as (usize))] = __brotli_swap_tmp;
+                            symbols.swap((j as (usize)), (i as (usize)));
                         }
                     }
                     j = j.wrapping_add(1 as (usize));

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -84,9 +84,7 @@ fn BrotliCompareAndPushToQueue<
     if idx1 == idx2 {
     } else {
         if idx2 < idx1 {
-            let t: u32 = idx2;
-            idx2 = idx1;
-            idx1 = t;
+            core::mem::swap(&mut idx2, &mut idx1);
         }
         p.idx1 = idx1;
         p.idx2 = idx2;

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -485,9 +485,7 @@ pub fn DecideOverRleUse(
 fn Reverse(v: &mut [u8], mut start: usize, mut end: usize) {
     end = end.wrapping_sub(1 as (usize));
     while start < end {
-        let tmp: u8 = v[(start as (usize))];
-        v[(start as (usize))] = v[(end as (usize))];
-        v[(end as (usize))] = tmp;
+        v.swap((start as (usize)), (end as (usize)));
         start = start.wrapping_add(1 as (usize));
         end = end.wrapping_sub(1 as (usize));
     }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -645,9 +645,7 @@ fn BlockSplitterFinishBlock<
             (*split).types.slice_mut()[((*xself).num_blocks_ as (usize))] =
                 (*split).types.slice()[((*xself).num_blocks_.wrapping_sub(2usize) as (usize))]; //FIXME: investigate copy?
             {
-                let mut __brotli_swap_tmp: usize = (*xself).last_histogram_ix_[0usize];
-                (*xself).last_histogram_ix_[0usize] = (*xself).last_histogram_ix_[1usize];
-                (*xself).last_histogram_ix_[1usize] = __brotli_swap_tmp;
+                (*xself).last_histogram_ix_.swap(0usize, 1usize);
             }
             histograms[((*xself).last_histogram_ix_[0usize] as (usize))] =
                 combined_histo[1usize].clone();
@@ -815,9 +813,7 @@ fn ContextBlockSplitterFinishBlock<
             (*split).types.slice_mut()[((*xself).num_blocks_ as (usize))] = nbm2;
 
             {
-                let mut __brotli_swap_tmp: usize = (*xself).last_histogram_ix_[0usize];
-                (*xself).last_histogram_ix_[0usize] = (*xself).last_histogram_ix_[1usize];
-                (*xself).last_histogram_ix_[1usize] = __brotli_swap_tmp;
+                (*xself).last_histogram_ix_.swap(0usize, 1usize);
             }
             i = 0usize;
             while i < num_contexts {


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::manual_swap
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/manual_swap