### PR TITLE
Auto-fixed clippy::default_constructed_unit_structs

### DIFF
--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -294,10 +294,7 @@ where
             alloc,
             f,
         );
-        *work = SendAlloc(InternalSendAlloc::Join(MTJoinable(
-            ret,
-            PhantomData::default(),
-        )));
+        *work = SendAlloc(InternalSendAlloc::Join(MTJoinable(ret, PhantomData)));
     }
 }
 impl<

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -182,7 +182,7 @@ where
             dict_num_lookups: 0,
             dict_num_matches: 0,
         },
-        _params: core::marker::PhantomData::<H10DefaultParams>::default(),
+        _params: core::marker::PhantomData::<H10DefaultParams>,
         window_mask_: window_mask as usize,
         invalid_pos_: invalid_pos,
         buckets_: buckets,
@@ -221,7 +221,7 @@ where
             buckets_: Buckets::new_uninit(m),
             invalid_pos_: self.invalid_pos_,
             forest: <Alloc as Allocator<u32>>::alloc_cell(m, self.forest.len()),
-            _params: core::marker::PhantomData::<Params>::default(),
+            _params: core::marker::PhantomData::<Params>,
         };
         ret.buckets_
             .slice_mut()

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -385,7 +385,7 @@ impl<SliceType: SliceWrapper<u8>> SliceWrapper<u8> for FeatureFlagSliceType<Slic
 #[cfg(not(feature = "external-literal-probability"))]
 impl<SliceType: SliceWrapper<u8> + Default> Default for FeatureFlagSliceType<SliceType> {
     fn default() -> Self {
-        FeatureFlagSliceType::<SliceType>(core::marker::PhantomData::<SliceType>::default())
+        FeatureFlagSliceType::<SliceType>(core::marker::PhantomData::<SliceType>)
     }
 }
 

--- a/src/enc/multithreading.rs
+++ b/src/enc/multithreading.rs
@@ -107,7 +107,7 @@ where
         let ret = spawn_work(extra_input, index, num_threads, input.clone(), alloc, f);
         *work = SendAlloc(InternalSendAlloc::Join(MultiThreadedJoinable(
             ret,
-            PhantomData::default(),
+            PhantomData,
         )));
     }
 }

--- a/src/enc/singlethreading.rs
+++ b/src/enc/singlethreading.rs
@@ -172,10 +172,10 @@ pub struct WorkerPool<A, B, C, D> {
 }
 pub fn new_work_pool<A, B, C, D>(_num_threads: usize) -> WorkerPool<A, B, C, D> {
     WorkerPool::<A, B, C, D> {
-        a: PhantomData::default(),
-        b: PhantomData::default(),
-        c: PhantomData::default(),
-        d: PhantomData::default(),
+        a: PhantomData,
+        b: PhantomData,
+        c: PhantomData,
+        d: PhantomData,
     }
 }
 

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -135,7 +135,7 @@ where
     pub fn replace_with_default(&mut self) -> (Alloc, ExtraInput) {
         match mem::replace(
             &mut self.0,
-            InternalSendAlloc::SpawningOrJoining(PhantomData::default()),
+            InternalSendAlloc::SpawningOrJoining(PhantomData),
         ) {
             InternalSendAlloc::A(alloc, extra_input) => (alloc, extra_input),
             InternalSendAlloc::SpawningOrJoining(_) | InternalSendAlloc::Join(_) => {
@@ -534,7 +534,7 @@ where
         } else {
             match mem::replace(
                 &mut thread.0,
-                InternalSendAlloc::SpawningOrJoining(PhantomData::default()),
+                InternalSendAlloc::SpawningOrJoining(PhantomData),
             ) {
                 InternalSendAlloc::A(_, _) | InternalSendAlloc::SpawningOrJoining(_) => {
                     panic!("Thread not properly spawned")


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all -W clippy::default_constructed_unit_structs
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs