### PR TITLE
Auto-fixed clippy::from_over_into

### DIFF
--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -40,9 +40,9 @@ impl From<BroCatli> for BroccoliState {
         }
     }
 }
-impl Into<BroCatli> for BroccoliState {
-    fn into(self) -> BroCatli {
-        BroCatli::deserialize_from_buffer(&self.current_data[..]).unwrap()
+impl From<BroccoliState> for BroCatli {
+    fn from(val: BroccoliState) -> Self {
+        BroCatli::deserialize_from_buffer(&val.current_data[..]).unwrap()
     }
 }
 


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all -W clippy::from_over_into
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/from_over_into