### PR TITLE
Auto-fixed clippy::needless_parens_on_range_literals

### DIFF
--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -258,7 +258,7 @@ fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
         num_bytes,
         ringbuffer_mask,
         ringbuffer,
-        &mut literal_costs[(1usize)..],
+        &mut literal_costs[1usize..],
     );
     literal_costs[(0usize)] = 0.0 as (floatX);
     i = 0usize;

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -670,11 +670,11 @@ fn BuildAndStoreCommandPrefixCode(
     let mut cmd_bits: [u16; 64] = [0; 64];
     BrotliCreateHuffmanTree(&histogram[..], 64usize, 15i32, &mut tree[..], depth);
     BrotliCreateHuffmanTree(
-        &histogram[(64usize)..],
+        &histogram[64usize..],
         64usize,
         14i32,
         &mut tree[..],
-        &mut depth[(64usize)..],
+        &mut depth[64usize..],
     );
     /* We have to jump through a few hoops here in order to compute
     the command bits because the symbols are in a different order than in
@@ -724,7 +724,7 @@ fn BuildAndStoreCommandPrefixCode(
     memcpy(bits, (40usize), &cmd_bits[..], 24i32 as (usize), 8usize);
     memcpy(bits, (48usize), &cmd_bits[..], 40i32 as (usize), 8usize);
     memcpy(bits, (56usize), &cmd_bits[..], 56i32 as (usize), 8usize);
-    BrotliConvertBitDepthsToSymbols(&mut depth[(64usize)..], 64usize, &mut bits[(64usize)..]);
+    BrotliConvertBitDepthsToSymbols(&mut depth[64usize..], 64usize, &mut bits[64usize..]);
     {
         let mut i: usize;
         for item in cmd_depth[..64].iter_mut() {
@@ -780,7 +780,7 @@ fn BuildAndStoreCommandPrefixCode(
         );
     }
     BrotliStoreHuffmanTree(
-        &mut depth[(64usize)..],
+        &mut depth[64usize..],
         64usize,
         &mut tree[..],
         storage_ix,

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -516,11 +516,11 @@ fn BuildAndStoreCommandPrefixCode(
     let mut cmd_bits: [u16; 64] = [0; 64];
     BrotliCreateHuffmanTree(histogram, 64usize, 15i32, &mut tree[..], depth);
     BrotliCreateHuffmanTree(
-        &histogram[(64usize)..],
+        &histogram[64usize..],
         64usize,
         14i32,
         &mut tree[..],
-        &mut depth[(64usize)..],
+        &mut depth[64usize..],
     );
     /* We have to jump through a few hoops here in order to compute
     the command bits because the symbols are in a different order than in
@@ -582,7 +582,7 @@ fn BuildAndStoreCommandPrefixCode(
         48i32 as (usize),
         8usize,
     );
-    BrotliConvertBitDepthsToSymbols(&mut depth[(64usize)..], 64usize, &mut bits[(64usize)..]);
+    BrotliConvertBitDepthsToSymbols(&mut depth[64usize..], 64usize, &mut bits[64usize..]);
     {
         let mut i: usize;
         for item in cmd_depth[..64].iter_mut() {
@@ -639,7 +639,7 @@ fn BuildAndStoreCommandPrefixCode(
         );
     }
     BrotliStoreHuffmanTree(
-        &mut depth[(64usize)..],
+        &mut depth[64usize..],
         64usize,
         &mut tree[..],
         storage_ix,

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -560,7 +560,7 @@ fn InitContextBlockSplitter<
     *histograms_size = max_num_types.wrapping_mul(num_contexts);
     *histograms = <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, *histograms_size);
     //(*xself).histograms_ = *histograms;
-    ClearHistograms(&mut histograms.slice_mut()[(0usize)..], num_contexts);
+    ClearHistograms(&mut histograms.slice_mut()[0usize..], num_contexts);
     xself.last_histogram_ix_[0] = 0;
     xself.last_histogram_ix_[1] = 0;
     return xself;


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all -W clippy::needless_parens_on_range_literals
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/needless_parens_on_range_literals