### PR TITLE
BREAKING: Use `default()` instead of `new()` for non-parameterized instantiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brotli"
-version = "3.4.0"
+version = "4.0.0"
 authors = ["Daniel Reiter Horn <danielrh@dropbox.com>", "The Brotli Authors"]
 description = "A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe."
 license = "BSD-3-Clause/MIT"

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -10,8 +10,8 @@ pub struct BlockSplit<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> {
     pub lengths: <Alloc as Allocator<u32>>::AllocatedMemory,
 }
 
-impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> BlockSplit<Alloc> {
-    pub fn new() -> BlockSplit<Alloc> {
+impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> Default for BlockSplit<Alloc> {
+    fn default() -> Self {
         BlockSplit {
             num_types: 0,
             num_blocks: 0,
@@ -19,6 +19,9 @@ impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> BlockSplit<Alloc> {
             lengths: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
         }
     }
+}
+
+impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> BlockSplit<Alloc> {
     pub fn destroy(&mut self, m: &mut Alloc) {
         <Alloc as Allocator<u8>>::free_cell(
             m,

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1341,13 +1341,26 @@ impl<
             + alloc::Allocator<HistogramLiteral>
             + alloc::Allocator<HistogramCommand>
             + alloc::Allocator<HistogramDistance>,
+    > Default for MetaBlockSplit<Alloc>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<
+        Alloc: alloc::Allocator<u8>
+            + alloc::Allocator<u32>
+            + alloc::Allocator<HistogramLiteral>
+            + alloc::Allocator<HistogramCommand>
+            + alloc::Allocator<HistogramDistance>,
     > MetaBlockSplit<Alloc>
 {
     pub fn new() -> Self {
         return MetaBlockSplit {
-            literal_split: BlockSplit::<Alloc>::new(),
-            command_split: BlockSplit::<Alloc>::new(),
-            distance_split: BlockSplit::<Alloc>::new(),
+            literal_split: BlockSplit::<Alloc>::default(),
+            command_split: BlockSplit::<Alloc>::default(),
+            distance_split: BlockSplit::<Alloc>::default(),
             literal_context_map: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
             literal_context_map_size: 0,
             distance_context_map: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
@@ -2994,8 +3007,8 @@ pub struct RecoderState {
     pub num_bytes_encoded: usize,
 }
 
-impl RecoderState {
-    pub fn new() -> Self {
+impl Default for RecoderState {
+    fn default() -> Self {
         RecoderState {
             num_bytes_encoded: 0,
         }

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -521,7 +521,7 @@ pub fn BrotliEncoderCreateInstance<Alloc: BrotliAlloc>(
         literal_scratch_space: HistogramLiteral::make_nnz_storage(),
         command_scratch_space: HistogramCommand::make_nnz_storage(),
         distance_scratch_space: HistogramDistance::make_nnz_storage(),
-        recoder_state: RecoderState::new(),
+        recoder_state: RecoderState::default(),
         custom_dictionary: false,
     }
 }


### PR DESCRIPTION
It is cleaner to have a standard default impl than a non-standard new method.

The crate major version must be incremented