### PR TITLE
Auto-fixed clippy::redundant_slicing

### DIFF
--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -919,7 +919,7 @@ fn benchmark_helper<Run: Runner>(
     params.quality = quality;
     params.q9_5 = q9_5;
     params.large_window = true;
-    let mut input = UnlimitedBuffer::new(&input_slice[..]);
+    let mut input = UnlimitedBuffer::new(input_slice);
     let mut compressed_array = vec![0; input_slice.len() * 100 / 99];
     let mut rt_array = vec![0; input_slice.len() + 1];
     let mut compressed = LimitedBuffer::new(&mut compressed_array[..]);
@@ -1020,16 +1020,7 @@ static UKKONOOA: &'static [u8] = include_bytes!("../../testdata/ukkonooa");
 #[test]
 fn test_ukkonooa() {
     let td = UKKONOOA;
-    benchmark_helper(
-        &td[..],
-        65536,
-        65536,
-        true,
-        true,
-        &mut Passthrough {},
-        11,
-        false,
-    );
+    benchmark_helper(td, 65536, 65536, true, true, &mut Passthrough {}, 11, false);
 }
 
 #[cfg(feature = "benchmark")]

--- a/src/bin/test_threading.rs
+++ b/src/bin/test_threading.rs
@@ -88,23 +88,23 @@ fn multi_threaded_split_compression_test(
 }
 #[test]
 fn multi_threaded_split_compression_test_1() {
-    multi_threaded_split_compression_test(&RANDOM_THEN_UNICODE[..], 1, 3, false, 155808)
+    multi_threaded_split_compression_test(RANDOM_THEN_UNICODE, 1, 3, false, 155808)
 }
 #[test]
 fn multi_threaded_split_compression_test_2() {
-    multi_threaded_split_compression_test(&RANDOM_THEN_UNICODE[..], 2, 4, false, 151857)
+    multi_threaded_split_compression_test(RANDOM_THEN_UNICODE, 2, 4, false, 151857)
 }
 #[test]
 fn multi_threaded_split_compression_test_3() {
-    multi_threaded_split_compression_test(&RANDOM_THEN_UNICODE[..], 3, 5, false, 144325)
+    multi_threaded_split_compression_test(RANDOM_THEN_UNICODE, 3, 5, false, 144325)
 }
 #[test]
 fn multi_threaded_split_compression_test_4() {
-    multi_threaded_split_compression_test(&RANDOM_THEN_UNICODE[..], 4, 10, true, 136812)
+    multi_threaded_split_compression_test(RANDOM_THEN_UNICODE, 4, 10, true, 136812)
 }
 #[test]
 fn multi_threaded_split_compression_test_5() {
-    multi_threaded_split_compression_test(&RANDOM_THEN_UNICODE[..], 5, 9, false, 139126)
+    multi_threaded_split_compression_test(RANDOM_THEN_UNICODE, 5, 9, false, 139126)
 }
 #[test]
 fn multi_threaded_split_compression_test_1b1() {
@@ -190,11 +190,11 @@ fn thread_spawn_per_job_split_compression_test(
 }
 #[test]
 fn thread_spawn_per_job_split_compression_test_1() {
-    thread_spawn_per_job_split_compression_test(&RANDOM_THEN_UNICODE[..], 1, 3, false, 155808)
+    thread_spawn_per_job_split_compression_test(RANDOM_THEN_UNICODE, 1, 3, false, 155808)
 }
 #[test]
 fn thread_spawn_per_job_split_compression_test_3() {
-    thread_spawn_per_job_split_compression_test(&RANDOM_THEN_UNICODE[..], 3, 5, false, 144325)
+    thread_spawn_per_job_split_compression_test(RANDOM_THEN_UNICODE, 3, 5, false, 144325)
 }
 #[test]
 fn thread_spawn_per_job_split_compression_test_1b1() {

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -668,7 +668,7 @@ fn BuildAndStoreCommandPrefixCode(
     let mut cmd_depth: [u8; 704] = [0i32 as (u8); 704];
 
     let mut cmd_bits: [u16; 64] = [0; 64];
-    BrotliCreateHuffmanTree(&histogram[..], 64usize, 15i32, &mut tree[..], depth);
+    BrotliCreateHuffmanTree(histogram, 64usize, 15i32, &mut tree[..], depth);
     BrotliCreateHuffmanTree(
         &histogram[64usize..],
         64usize,

--- a/src/enc/reader.rs
+++ b/src/enc/reader.rs
@@ -236,7 +236,7 @@ impl<ErrType, R: CustomRead<ErrType>, BufferType: SliceWrapperMut<u8>, Alloc: Br
                 &mut self.state.0,
                 op,
                 &mut avail_in,
-                &self.input_buffer.slice_mut()[..],
+                self.input_buffer.slice_mut(),
                 &mut self.input_offset,
                 &mut avail_out,
                 buf,

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -248,7 +248,7 @@ pub fn ComplexFindMatchLengthWithLimit(mut s1: &[u8], mut s2: &[u8], mut limit: 
 mod test {
     #[allow(unused)]
     fn construct_situation(seed: &[u8], mut output: &mut [u8], limit: usize, matchfor: usize) {
-        output[..].clone_from_slice(&seed[..]);
+        output[..].clone_from_slice(seed);
         if matchfor >= limit {
             return;
         }

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -248,7 +248,7 @@ fn oneshot_decompress(compressed: &[u8], output: &mut [u8]) -> (BrotliResult, us
     let result = BrotliDecompressStream(
         &mut available_in,
         &mut input_offset,
-        &compressed[..],
+        compressed,
         &mut available_out,
         &mut output_offset,
         output,

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -266,7 +266,7 @@ impl<ErrType, W: CustomWrite<ErrType>, BufferType: SliceWrapperMut<u8>, Alloc: B
                 &mut self.state,
                 BrotliEncoderOperation::BROTLI_OPERATION_PROCESS,
                 &mut avail_in,
-                &buf[..],
+                buf,
                 &mut input_offset,
                 &mut avail_out,
                 self.output_buffer.slice_mut(),


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all -W clippy::redundant_slicing
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_slicing