### PR TITLE
Workspace with brotli and brotli-ffi crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "c"]
+default-members = [".", "c"]
+
 [package]
 name = "brotli"
 version = "3.4.0"
@@ -27,9 +31,9 @@ incremental = false
 
 [dependencies]
 "alloc-no-stdlib" = { version = "2.0" }
-"alloc-stdlib" = { version = "~0.2", optional = true }
-"brotli-decompressor" = { version = "~2.5", default-features = false }
-"sha2" = { version = "~0.10", optional = true }
+"alloc-stdlib" = { version = "0.2", optional = true }
+"brotli-decompressor" = { version = "2.5", default-features = false }
+"sha2" = { version = "0.10", optional = true }
 "packed_simd" = { git = "https://github.com/programingjd/packed_simd.git", rev = "53efe013875b7f23ecc1edd840a20c4cbce3f302", default-features = false, features = ["into_bits"], optional = true }
 
 [features]

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -16,18 +16,16 @@ autobins = false
 path = "src/lib.rs"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
-[profile.release]
-lto = true
-
 [dependencies]
-"brotli" = { version = "~3.3", default-features = false, features = ["ffi-api"] }
+"brotli" = { version = "3.4", default-features = false, features = ["ffi-api"], path = ".." }
 
 [features]
 default = ["std"]
 benchmark = ["brotli/benchmark"]
 disable-timer = ["brotli/disable-timer"]
 seccomp = ["brotli/seccomp"]
-simd = ["brotli/simd"]
+# Uncomment once brotli package supports simd feature again
+# simd = ["brotli/simd"]
 std = ["brotli/std"]
 validation = ["brotli/validation"]
 vector_scratch_space = ["brotli/vector_scratch_space"]


### PR DESCRIPTION
* make both packages into a single workspace
* make `brotli-ffi` use latest `brotli` version
* commented out `brotli-ffi` `simd` feature because it is no longer available