### PR TITLE
Detected suspicious code, needs feedback

### DIFF
--- a/src/bin/test_custom_dict.rs
+++ b/src/bin/test_custom_dict.rs
@@ -109,8 +109,8 @@ fn test_custom_dict_for_multithreading() {
     }
     let mut bro_cat_li = BroCatli::new();
     let mut output = UnlimitedBuffer::new(&[]);
-    let mut ibuffer = vec![0u8; 1];
-    let mut obuffer = vec![0u8; 1];
+    let mut ibuffer = [0u8; 1];
+    let mut obuffer = [0u8; 1];
     let mut ooffset = 0usize;
     for brotli in brs.iter_mut() {
         brotli.reset_read();

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -159,7 +159,6 @@ pub fn write_one<T: SliceWrapper<u8>>(cmd: &interface::Command<T>) {
                 dict.transform as i32,
             ) as usize;
 
-            transformed_word.split_at(actual_copy_len).0;
             assert_eq!(dict.final_size as usize, actual_copy_len);
             println_stderr!(
                 "dict {} word {},{} {:x} func {} {:x}",


### PR DESCRIPTION
* `write_one` in utils.rs uses `transformed_word.split_at(actual_copy_len).0;` in `interface::Command::Dict` -- this is a noop, can be safely removed, but may indicate there is a bug there.

* `test_custom_dict_for_multithreading` creates two vectors of 1 byte each, and they never grow - so clippy suggested to switch it to simple 1-element arrays. Not sure if this was intended, but this is a test...?