### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly
       - name: Run `just ci-test` to lint, build, and test everything
         run: just ci-test
       - name: Check if changes break public API and need a new version. Use `just semver-checks` to run locally.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brotli"
-version = "5.0.0"
+version = "6.0.0"
 authors = ["Daniel Reiter Horn <danielrh@dropbox.com>", "The Brotli Authors"]
 description = "A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe."
 license = "BSD-3-Clause OR MIT"
@@ -11,6 +11,7 @@ keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
 categories = ["compression", "no-std"]
 readme = "README.md"
 autobins = false
+edition = "2015"
 rust-version = "1.56.0"
 
 [[bin]]

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -5,7 +5,11 @@ extern crate std;
 
 pub extern crate brotli;
 pub use brotli::ffi::compressor::*;
+
+// FIXME: this is just wrong, and needs to be fixed
+#[allow(unknown_lints, ambiguous_glob_reexports)]
 pub use brotli::ffi::decompressor::*;
+
 pub use brotli::ffi::multicompress::*;
 pub use brotli::*;
 use core::ptr::null_mut;

--- a/justfile
+++ b/justfile
@@ -20,8 +20,7 @@ build-simd:
 
 # Build the brotli-ffi crate (in ./c dir)
 build-ffi:
-    # TODO change to this:   RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples --manifest-path c/Cargo.toml
-    cargo build --workspace --all-targets --bins --tests --lib --benches --examples --manifest-path c/Cargo.toml
+    RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples --manifest-path c/Cargo.toml
     # For now, use original make file for building/testing the FFI crate
     cd c && make
 
@@ -72,7 +71,7 @@ read-msrv:
 ci-test: sys-info (fmt "--check") build test test-doc
 
 # All stable tests to run for CI with the earliest supported Rust version. Assumes the Rust version is already set by rustup.
-ci-test-msrv: sys-info build test
+ci-test-msrv: sys-info build-brotli build-ffi test
 
 # Test if changes are backwards compatible (patch), or need a new minor/major version
 semver-checks:

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 use core::mem;
-use std;
 use std::thread::JoinHandle;
 
 use alloc_no_stdlib::{Allocator, SliceWrapper};

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -2,8 +2,6 @@
 use super::super::alloc::SliceWrapper;
 use super::histogram::CostAccessors;
 use core::cmp::{max, min};
-#[cfg(feature = "simd")]
-use core::simd::prelude::SimdPartialOrd;
 
 use super::util::{FastLog2, FastLog2u16};
 use super::vectorization::Mem256i;

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use super::super::alloc;
 use super::super::alloc::Allocator;
 use super::super::alloc::SliceWrapper;
 

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -2,7 +2,6 @@
 use super::backward_references::BrotliEncoderParams;
 use super::vectorization::{sum8i, v256, v256i, Mem256f};
 
-use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::bit_cost::BrotliPopulationCost;
 use super::block_split::BlockSplit;
@@ -13,7 +12,6 @@ use super::histogram::{
     HistogramClear, HistogramCommand, HistogramDistance, HistogramLiteral,
 };
 use super::util::FastLog2;
-use core;
 use core::cmp::{max, min};
 #[cfg(feature = "simd")]
 use core::simd::prelude::{SimdFloat, SimdPartialOrd};

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -4,9 +4,7 @@ use super::histogram::{
     CostAccessors, HistogramAddHistogram, HistogramClear, HistogramSelfAddHistogram,
 };
 use super::util::FastLog2;
-use alloc;
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core;
 use core::cmp::min;
 #[derive(Clone, Copy)]
 pub struct HistogramPair {

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -9,7 +9,6 @@ use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHu
 // the hoops that BuildAndStoreCommandPrefixCode goes through are subtly different in order
 // (eg memcpy x+24, y instead of +24, y+40
 // pretty much assume compress_fragment_two_pass is a trap! except for BrotliStoreMetaBlockHeader
-use super::super::alloc;
 use super::compress_fragment_two_pass::{memcpy, BrotliStoreMetaBlockHeader, BrotliWriteBits};
 use super::entropy_encode::{
     BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree,

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 use super::backward_references::kHashMul32;
-//use super::super::alloc::{SliceWrapper, SliceWrapperMut};
-use super::super::alloc;
 use super::bit_cost::BitsEntropy;
 use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
 use super::entropy_encode::{
@@ -12,7 +10,6 @@ use super::static_dict::{
     BROTLI_UNALIGNED_STORE64,
 };
 use super::util::Log2FloorNonZero;
-use core;
 use core::cmp::min;
 static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17) as usize;
 

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -1,4 +1,3 @@
-use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::find_stride;
 use super::input_pair::{InputPair, InputReference, InputReferenceMut};
@@ -6,7 +5,6 @@ use super::interface;
 pub use super::ir_interpret::{push_base, Context, IRInterpreter};
 use super::util::{floatX, FastLog2u16};
 use super::weights::{Weights, BLEND_FIXED_POINT_PRECISION};
-use core;
 
 const DEFAULT_CM_SPEED_INDEX: usize = 8;
 const NUM_SPEEDS_TO_TRY: usize = 16;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -25,7 +25,6 @@ use super::interface;
 pub use super::parameters::BrotliEncoderParameter;
 use alloc::Allocator;
 
-use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::command::{BrotliDistanceParams, Command, GetLengthCode};
 use super::compress_fragment::BrotliCompressFragmentFast;
@@ -44,7 +43,6 @@ use super::metablock::{
 use super::static_dict::{kNumDistanceCacheEntries, BrotliGetDictionary};
 use super::utf8_util::BrotliIsMostlyUTF8;
 use super::util::Log2FloorNonZero;
-use core;
 use core::cmp::{max, min};
 use enc::input_pair::InputReferenceMut;
 //fn BrotliCreateHqZopfliBackwardReferences(m: &mut [MemoryManager],

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -1,4 +1,3 @@
-use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::input_pair::{InputPair, InputReference};
 use super::interface;

--- a/src/enc/fixed_queue.rs
+++ b/src/enc/fixed_queue.rs
@@ -1,4 +1,3 @@
-use core;
 pub const MAX_THREADS: usize = 16;
 
 pub struct FixedQueue<T: Sized> {

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -1,12 +1,10 @@
 #![allow(dead_code)]
 
-use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::block_split::BlockSplit;
 use super::command::Command;
 use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
 use super::vectorization::Mem256i;
-use core;
 use core::cmp::min;
 static kBrotliMinWindowBits: i32 = 10i32;
 

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -1,7 +1,6 @@
 use super::super::alloc::SliceWrapper;
 use super::super::alloc::SliceWrapperMut;
 use super::interface::Freezable;
-use core;
 use core::cmp::min;
 #[derive(Copy, Clone, Default, Debug)]
 pub struct InputReference<'a> {

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::backward_references::BrotliEncoderParams;
 use super::bit_cost::{BitsEntropy, BrotliPopulationCost};
@@ -20,7 +19,6 @@ use super::histogram::{
     HistogramAddHistogram, HistogramAddItem, HistogramClear, HistogramCommand, HistogramDistance,
     HistogramLiteral,
 };
-use core;
 use core::cmp::{max, min};
 
 pub fn BrotliInitDistanceParams(params: &mut BrotliEncoderParams, npostfix: u32, ndirect: u32) {

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -43,8 +43,6 @@ pub mod singlethreading;
 pub mod threading;
 pub mod worker_pool;
 #[cfg(feature = "simd")]
-use core::simd::{f32x8, i16x16, i32x8};
-#[cfg(feature = "simd")]
 pub type s16 = core::simd::i16x16;
 #[cfg(feature = "simd")]
 pub type v8 = core::simd::f32x8;

--- a/src/enc/multithreading.rs
+++ b/src/enc/multithreading.rs
@@ -10,7 +10,6 @@ use enc::threading::{
 };
 use enc::BrotliAlloc;
 use enc::BrotliEncoderParams;
-use std;
 use std::thread::JoinHandle;
 
 // in-place thread create

--- a/src/enc/pdf.rs
+++ b/src/enc/pdf.rs
@@ -1,4 +1,6 @@
 //TODO: replace with builtin SIMD type
 
+// FIXME!!!
+#[allow(dead_code)]
 #[derive(Copy, Clone, Default, Debug)]
 pub struct PDF([i16; 16]);

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -1,4 +1,3 @@
-use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::backward_references::BrotliEncoderParams;
 use super::find_stride;
@@ -7,7 +6,6 @@ use super::interface;
 use super::ir_interpret::{push_base, IRInterpreter};
 use super::util::{floatX, FastLog2u16};
 use super::{s16, v8};
-use core;
 use core::cmp::min;
 #[cfg(feature = "simd")]
 use core::simd::prelude::SimdPartialOrd;

--- a/src/enc/singlethreading.rs
+++ b/src/enc/singlethreading.rs
@@ -9,8 +9,6 @@ use enc::threading::{
 };
 use enc::BrotliAlloc;
 use enc::BrotliEncoderParams;
-#[cfg(feature = "std")]
-use std;
 
 pub struct SingleThreadedJoinable<T: Send + 'static, U: Send + 'static> {
     result: Result<T, U>,

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -1,4 +1,3 @@
-use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::backward_references::BrotliEncoderParams;
 use super::input_pair::{InputPair, InputReference, InputReferenceMut};
@@ -6,7 +5,6 @@ use super::interface;
 use super::ir_interpret::{push_base, IRInterpreter};
 use super::prior_eval::DEFAULT_SPEED;
 use super::util::{floatX, FastLog2u16};
-use core;
 const NIBBLE_PRIOR_SIZE: usize = 16;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * NIBBLE_PRIOR_SIZE * 2;
 

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -11,8 +11,6 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::Range;
 use enc::encode::BrotliEncoderStateStruct;
-#[cfg(feature = "std")]
-use std;
 
 pub type PoisonedThreadError = ();
 

--- a/src/enc/vectorization.rs
+++ b/src/enc/vectorization.rs
@@ -1,8 +1,6 @@
 #![allow(unknown_lints)]
 #![allow(unused_macros)]
 
-#[cfg(feature = "simd")]
-use core::simd::Simd;
 use enc::util::FastLog2;
 use enc::{s8, v8};
 pub type Mem256f = v8;

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "std")]
 use core::mem;
-use std;
 
 use alloc::{Allocator, SliceWrapper};
 use enc::backward_references::UnionHasher;


### PR DESCRIPTION
This fixes issues at the https://github.com/rust-brotli/rust-brotli/pull/43/checks github CI builds.  If this project is to be successful, we must start using CI for every PR as a guarantee of code quality.

* Bump version to 6.0 (per semver check)
* Remove unused SIMD use statements
* hide a few warnings - these are TODOs, and should be fixed in separate PRs
* do NOT build SIMD as part of MSRV -- doesn't make any sense to combine nightly with MSRV
* set edition explicitly to 2015.  We should bump it soon - it makes no sense to use an older edition when we have MSRV